### PR TITLE
Added a check if './css is empty' to oomoxify.sh

### DIFF
--- a/oomoxify.sh
+++ b/oomoxify.sh
@@ -181,7 +181,7 @@ for file in "${backup_dir}"/*.spa ; do
 	cp "${file}" "${tmp_dir}/"
 	cd "${tmp_dir}"
 	unzip "./${filename}" > /dev/null
-	if [[ -d ./css/ ]] ; then
+	if [[ -d ./css/ ]] && [[ ! -z "$(ls ./css)" ]]; then
 		for css in ./css/*.css ; do
 			if [ -n "${THEME:-}" ] ; then
 			sed -i \


### PR DESCRIPTION
script failed if ./css was empty

Tested on
OS: 5.6.3-arch1-1
Spotify: spotify-dev 1.1.26.501-1
Oomoxify: commit 'b476c6f35bfd1dc8a813d12f2b19234dae0ec1e8'